### PR TITLE
Support for automatic request cancellation with abortOnUnmount flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "react-refetch",
+  "name": "@iloveupal/react-refetch",
   "version": "2.0.3",
-  "description": "A simple, declarative, and composable way to fetch data for React components.",
+  "description": "A fork of @heroku/react-refetch. A simple, declarative, and composable way to fetch data for React components.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/heroku/react-refetch.git"
+    "url": "https://github.com/iloveupal/react-refetch.git"
   },
   "files": [
     "lib"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -66,6 +66,7 @@ export interface Connect {
 export interface ConnectOptions {
   withRef?: boolean;
   pure?: boolean;
+  abortOnUnmount?: boolean;
 }
 
 export type MapPropsToRequestsToProps<T> = (


### PR DESCRIPTION
There's probably not much sense for the requests to go on if the component that is responsible for creating them, is gone. 

This PR adds an ability to **opt-in** for automatic request cancellation on component's unmount event.

Technically this is done with `AbortController` specification which seems to be supported very well.